### PR TITLE
feat: make library work on Android

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -35,6 +35,7 @@ extern "C" {
         serial_number: *const wchar_t,
     ) -> *mut HidDevice;
     pub fn hid_open_path(path: *const c_char) -> *mut HidDevice;
+    pub fn hid_libusb_wrap_sys_device(sys_dev: *mut c_int, interface_num: c_int) -> *mut HidDevice;
     pub fn hid_write(device: *mut HidDevice, data: *const c_uchar, length: size_t) -> c_int;
     pub fn hid_read_timeout(
         device: *mut HidDevice,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,29 @@ impl HidApi {
         }
     }
 
+    /// Open a HID device using `libusb_wrap_sys_device`. Useful for Android.
+    ///
+    /// ### Arguments
+    ///
+    /// * `sys_dev`: Platform-specific file descriptor that can be recognised by libusb.
+    /// * `interface_num`: USB interface number of the device to be used as HID interface. Pass -1
+    /// to select first HID interface of the device.
+    pub fn wrap_sys_device(&self, sys_dev: i32, interface_num: i32) -> HidResult<HidDevice> {
+        let device = unsafe { ffi::hid_libusb_wrap_sys_device(sys_dev as _, interface_num) };
+
+        if device.is_null() {
+            match self.check_error() {
+                Ok(err) => Err(err),
+                Err(e) => Err(e),
+            }
+        } else {
+            Ok(HidDevice {
+                _hid_device: device,
+                _lock: ManuallyDrop::new(self._lock.clone()),
+            })
+        }
+    }
+
     /// Get the last non-device specific error, which happened in the underlying hidapi C library.
     /// To get the last device specific error, use [`HidDevice::check_error`].
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,13 @@ impl HidApiLock {
         {
             // Initialize the HID and prevent other HIDs from being created
             unsafe {
+                // This option must be set for Android Termux
+                #[cfg(target_os = "android")]
+                rusb::ffi::libusb_set_option(
+                    std::ptr::null_mut(),
+                    rusb::ffi::constants::LIBUSB_OPTION_WEAK_AUTHORITY,
+                );
+
                 if ffi::hid_init() == -1 {
                     HID_API_LOCK.store(false, Ordering::SeqCst);
                     return Err(HidError::InitializationError);


### PR DESCRIPTION
This PR:

- exposes an underlying method `hid_libusb_wrap_sys_device` through `HidApi::wrap_sys_device()`; this method is necessary for working with already-opened file descriptors on device nodes, which is in turn needed for unrooted Android devices; and
- sets the `LIBUSB_OPTION_WEAK_AUTHORITY` option on Android for unrooted devices to work.

Some background here. I'm working on adding Android [Termux](https://github.com/termux/termux-app) support to a downstream lib [bitcoins-rs](https://github.com/summa-tx/bitcoins-rs) here:

https://github.com/summa-tx/bitcoins-rs/issues/94

These changes in the PR are necessary for `libusb` to work properly on Android, at least on Termux. Tested with a Ledger wallet device.