### PR TITLE
chore: skip compiling libusb on docs.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -96,6 +96,11 @@ fn compile_linux() {
         (
             "LINUX_STATIC_RUSB",
             Box::new(|| {
+                // https://docs.rs/about/builds#detecting-docsrs
+                if env::var("DOCS_RS").is_ok() {
+                    return;
+                }
+
                 // It's expecting it to be on the system, but the file is local
                 replace_on_file("etc/hidapi/libusb/hid.c", "<libusb.h>", "\"libusb.h\"");
 


### PR DESCRIPTION
Not sure if we can skip compilation and still have the package build fine, but if we can then this should work I believe