### PR TITLE
Fix build on docs.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,10 +20,7 @@
 extern crate cc;
 extern crate pkg_config;
 
-use std::{
-    env,
-    io::{Read, Write},
-};
+use std::env;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
@@ -40,22 +37,6 @@ fn main() {
         compile_illumos();
     } else {
         panic!("Unsupported target os for hidapi-rs");
-    }
-}
-
-fn replace_on_file(path: &str, old: &str, new: &str) {
-    let mut prev_contents = String::new();
-
-    {
-        let mut f = std::fs::OpenOptions::new().read(true).open(path).unwrap();
-        f.read_to_string(&mut prev_contents).unwrap();
-        prev_contents = prev_contents.replace(old, new);
-    }
-
-    {
-        let mut f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
-        f.write(prev_contents.as_bytes()).unwrap();
-        f.flush().unwrap();
     }
 }
 
@@ -96,17 +77,12 @@ fn compile_linux() {
         (
             "LINUX_STATIC_RUSB",
             Box::new(|| {
-                // It's expecting it to be on the system, but the file is local
-                replace_on_file("etc/hidapi/libusb/hid.c", "<libusb.h>", "\"libusb.h\"");
-
                 let mut config = cc::Build::new();
                 config
                     .file("etc/hidapi/libusb/hid.c")
                     .include("etc/")
                     .include("etc/hidapi/hidapi");
                 config.compile("libhidapi.a");
-
-                replace_on_file("etc/hidapi/libusb/hid.c", "\"libusb.h\"", "<libusb.h>");
             }),
         ),
         (


### PR DESCRIPTION
Modification of `hid.c` is not really needed because `.include("etc/")` will prioritize the search of `libusb.h` in `etc` directory.