### PR TITLE
fix: remove `libusb` dependency from `macos` build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,4 +49,13 @@ jobs:
       - name: Check for libusb
         run: |
           otool -L target/debug/examples/open_first_device | grep libusb && exit 1 || exit 0
-
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --example open_first_device
+        env:
+          RUSTFLAGS: "--print link-args"
+    - name: Build
+      run: cargo build --no-default-features --features linux-static-hidraw --verbose
+    - name: Run tests
+      run: cargo test --no-default-features --features linux-static-hidraw --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,49 +13,45 @@ jobs:
   build-ubuntu:
     runs-on: ubuntu-latest
     steps:
-    - name: checkout repository and submodules
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libudev-dev
-    - name: Build
-      run: cargo build --no-default-features --features linux-static-hidraw --verbose
-    - name: Run tests
-      run: cargo test --no-default-features --features linux-static-hidraw --verbose
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libudev-dev
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: Build
+        run: cargo build --no-default-features --features linux-static-hidraw --verbose
+      - name: Run tests
+        run: cargo test --no-default-features --features linux-static-hidraw --verbose
 
   build-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: actions-rs/toolchain@v1
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-          target: x86_64-apple-darwin
-      - uses: Swatinem/rust-cache@v2
-      - run: env
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --example open_first_device
-        env:
-          RUSTFLAGS: "--print link-args"
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+      - name: Build example
+        run: cargo build --example open_first_device --verbose
       - name: Check for libusb
         run: |
           otool -L target/debug/examples/open_first_device | grep libusb && exit 1 || exit 0
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --example open_first_device
-        env:
-          RUSTFLAGS: "--print link-args"
-    - name: Build
-      run: cargo build --no-default-features --features linux-static-hidraw --verbose
-    - name: Run tests
-      run: cargo test --no-default-features --features linux-static-hidraw --verbose
+      - name: Build
+        run: cargo build --no-default-features --features linux-static-hidraw --verbose
+      - name: Run tests
+        run: cargo test --no-default-features --features linux-static-hidraw --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
       - run: env
       - uses: actions-rs/cargo@v1
         with:
-          command: build --examples open_first_device
+          command: build --example open_first_device
         env:
           RUSTFLAGS: "--print link-args"
       - run: otool -L target/debug/examples/open_first_device

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
       - run: env
       - uses: actions-rs/cargo@v1
         with:
-          command: build 
+          command: build --examples open_first_device
         env:
           RUSTFLAGS: "--print link-args"
       - run: otool -L target/debug/examples/open_first_device

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,8 @@ jobs:
       - run: env
       - uses: actions-rs/cargo@v1
         with:
-          command: build --example open_first_device
+          command: build
+          args: --example open_first_device
         env:
           RUSTFLAGS: "--print link-args"
       - run: otool -L target/debug/examples/open_first_device

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,18 +13,18 @@ jobs:
   build-ubuntu:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout repository and submodules
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y libudev-dev
-      - name: Build
-        run: cargo build --no-default-features --features linux-static-hidraw --verbose
-      - name: Run tests
-        run: cargo test --no-default-features --features linux-static-hidraw --verbose
+    - name: checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y libudev-dev
+    - name: Build
+      run: cargo build --no-default-features --features linux-static-hidraw --verbose
+    - name: Run tests
+      run: cargo test --no-default-features --features linux-static-hidraw --verbose
 
   build-macos:
     runs-on: macos-latest
@@ -46,4 +46,7 @@ jobs:
           args: --example open_first_device
         env:
           RUSTFLAGS: "--print link-args"
-      - run: otool -L target/debug/examples/open_first_device
+      - name: Check for libusb
+        run: |
+          otool -L target/debug/examples/open_first_device | grep libusb && exit 1 || exit 0
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,9 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,20 +10,37 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  build-ubuntu:
     runs-on: ubuntu-latest
-
     steps:
-    - name: checkout repository and submodules
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: Install dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y libudev-dev
-    - name: Build
-      run: cargo build --no-default-features --features linux-static-hidraw --verbose
-    - name: Run tests
-      run: cargo test --no-default-features --features linux-static-hidraw --verbose
+      - name: checkout repository and submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libudev-dev
+      - name: Build
+        run: cargo build --no-default-features --features linux-static-hidraw --verbose
+      - name: Run tests
+        run: cargo test --no-default-features --features linux-static-hidraw --verbose
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+          target: x86_64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+      - run: env
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build 
+        env:
+          RUSTFLAGS: "--print link-args"
+      - run: otool -L target/debug/examples/open_first_device

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hidapi-rusb"
-version = "1.3.2"
+version = "1.3.3"
 authors = [
     "joshieDo <ranriver@protonmail.com>",
     "Roland Ruckerbauer <roland.rucky@gmail.com>",

--- a/examples/co2mon.rs
+++ b/examples/co2mon.rs
@@ -8,7 +8,7 @@
 //! Opens a KIT MT 8057 CO2 detector and reads data from it. This
 //! example will not work unless such an HID is plugged in to your system.
 
-#[cfg(feature = "linux-static-rusb")]
+#[cfg(all(feature = "linux-static-rusb", not(target_os = "macos")))]
 extern crate rusb;
 
 extern crate hidapi_rusb;

--- a/examples/lshid.rs
+++ b/examples/lshid.rs
@@ -6,7 +6,7 @@
 
 //! Prints out a list of HID devices
 
-#[cfg(feature = "linux-static-rusb")]
+#[cfg(all(feature = "linux-static-rusb", not(target_os = "macos")))]
 extern crate rusb;
 
 extern crate hidapi_rusb;

--- a/examples/open_first_device.rs
+++ b/examples/open_first_device.rs
@@ -7,7 +7,7 @@
 //! Opens the first hid device it can find, and reads data in a blocking fashion
 //! from it in an endless loop.
 
-#[cfg(feature = "linux-static-rusb")]
+#[cfg(all(feature = "linux-static-rusb", not(target_os = "macos")))]
 extern crate rusb;
 
 extern crate hidapi_rusb;

--- a/examples/readhid.rs
+++ b/examples/readhid.rs
@@ -8,7 +8,7 @@
 //! example will not work unless such an HID is plugged in to your system.
 //! Will update in the future to support all HIDs.
 
-#[cfg(feature = "linux-static-rusb")]
+#[cfg(all(feature = "linux-static-rusb", not(target_os = "macos")))]
 extern crate rusb;
 
 extern crate hidapi_rusb;

--- a/examples/static_lifetime_bound.rs
+++ b/examples/static_lifetime_bound.rs
@@ -7,7 +7,7 @@ This file is part of hidapi-rs, based on hidapi_rust by Roland Ruckerbauer.
 //! This example shows the added possibility (after version 0.4.1),
 //! to move devices into a function / or closure with static lifetime bounds.
 
-#[cfg(feature = "linux-static-rusb")]
+#[cfg(all(feature = "linux-static-rusb", not(target_os = "macos")))]
 extern crate rusb;
 
 extern crate hidapi_rusb;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 // Allow use of deprecated items, we defined ourselfes...
 #![allow(deprecated)]
 
-#[cfg(feature = "linux-static-rusb")]
+#[cfg(all(feature = "linux-static-rusb", not(target_os = "macos")))]
 extern crate rusb;
 
 extern crate libc;
@@ -235,7 +235,7 @@ impl HidApi {
     /// * `sys_dev`: Platform-specific file descriptor that can be recognised by libusb.
     /// * `interface_num`: USB interface number of the device to be used as HID interface. Pass -1
     /// to select first HID interface of the device.
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "macos")))]
     pub fn wrap_sys_device(&self, sys_dev: i32, interface_num: i32) -> HidResult<HidDevice> {
         let device = unsafe { ffi::hid_libusb_wrap_sys_device(sys_dev as _, interface_num) };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! extern crate hidapi;
+//! extern crate hidapi_rusb;
 //!
-//! use hidapi::HidApi;
+//! use hidapi_rusb::HidApi;
 //!
 //! fn main() {
 //!     println!("Printing all available hid devices:");


### PR DESCRIPTION
Always has been strange, since mac uses other libraries (IOKit, CoreFoundation, AppKit) to fulfill `hidapi` requests.

ty @naps62 ref #6 
